### PR TITLE
Generalise syntax restrictions in preparation for loss functions

### DIFF
--- a/src/MiniVehicle.agda
+++ b/src/MiniVehicle.agda
@@ -1,25 +1,29 @@
 {-# OPTIONS --postfix-projections --safe #-}
 
-module MiniVehicle where
+open import MiniVehicle.Restriction
+
+module MiniVehicle (R : SyntaxRestriction) where
 
 open import Data.Fin using (Fin)
 open import Data.Nat using (ℕ)
 open import Data.Rational using (ℚ)
 
-open import MiniVehicle.Qualifiers
+open SyntaxRestriction R
 
 data Kind : Set where
-  Nat Type Linearity Polarity : Kind
+  Nat Type NumRes BoolRes : Kind
 
 data SmallKind : Kind → Set where
-  Nat       : SmallKind Nat
-  Linearity : SmallKind Linearity
-  Polarity  : SmallKind Polarity
+  Nat    : SmallKind Nat
+  NumRes : SmallKind NumRes
+  BoolRes : SmallKind BoolRes
 
 data KindContext : Set where
   ε    : KindContext
   _,-_ : KindContext → Kind → KindContext
 
+private variable Δ : KindContext
+    
 data _⊢Tv_ : KindContext → Kind → Set where
   zero : ∀ {Δ κ} → (Δ ,- κ) ⊢Tv κ
   succ : ∀ {Δ κ κ'} → Δ ⊢Tv κ → (Δ ,- κ') ⊢Tv κ
@@ -35,42 +39,57 @@ wk : ∀ {K κ} → (K ,- κ) ⇒ᵣ K
 wk = succ
 
 data _⊢T_ : KindContext → Kind → Set where
-  var    : ∀ {Δ κ} → Δ ⊢Tv κ → Δ ⊢T κ
-  _⇒_   : ∀ {Δ} → Δ ⊢T Type → Δ ⊢T Type → Δ ⊢T Type
-  Forall : ∀ {Δ κ} → SmallKind κ → (Δ ,- κ) ⊢T Type → Δ ⊢T Type
+  var    : ∀ {κ} → Δ ⊢Tv κ → Δ ⊢T κ
+  _⇒_   : Δ ⊢T Type → Δ ⊢T Type → Δ ⊢T Type
+  Forall : ∀ {κ} → SmallKind κ → (Δ ,- κ) ⊢T Type → Δ ⊢T Type
 
-  Bool   : ∀ {Δ} → Δ ⊢T Linearity → Δ ⊢T Polarity → Δ ⊢T Type
-  Num    : ∀ {Δ} → Δ ⊢T Linearity → Δ ⊢T Type
+  Bool   : Δ ⊢T BoolRes → Δ ⊢T Type
+  Num    : Δ ⊢T NumRes → Δ ⊢T Type
 
-  Index  : ∀ {Δ} → Δ ⊢T Nat → Δ ⊢T Type
-  Vec    : ∀ {Δ} → Δ ⊢T Nat → Δ ⊢T Type → Δ ⊢T Type
-  [_]    : ∀ {Δ} → ℕ → Δ ⊢T Nat
+  Index  : Δ ⊢T Nat → Δ ⊢T Type
+  Vec    : Δ ⊢T Nat → Δ ⊢T Type → Δ ⊢T Type
+  [_]    : ℕ → Δ ⊢T Nat
 
-  LinearityConst : ∀ {Δ} → LinearityVal → Δ ⊢T Linearity
-  PolarityConst  : ∀ {Δ} → PolarityVal → Δ ⊢T Polarity
-  MaxLin   : ∀ {Δ} → Δ ⊢T Linearity → Δ ⊢T Linearity → Δ ⊢T Linearity → Δ ⊢T Type
-  HasMul   : ∀ {Δ} → Δ ⊢T Linearity → Δ ⊢T Linearity → Δ ⊢T Linearity → Δ ⊢T Type
-  MaxPol   : ∀ {Δ} → Δ ⊢T Polarity → Δ ⊢T Polarity → Δ ⊢T Polarity → Δ ⊢T Type
-  NegPol   : ∀ {Δ} → Δ ⊢T Polarity → Δ ⊢T Polarity → Δ ⊢T Type
-  Quantify : ∀ {Δ} → Δ ⊢T Polarity → Δ ⊢T Polarity → Δ ⊢T Type
-
+  NumRes : NumRestriction → Δ ⊢T NumRes
+  NumConstRes : Δ ⊢T NumRes → Δ ⊢T Type
+  FuncRes     : Δ ⊢T NumRes → Δ ⊢T NumRes → Δ ⊢T Type
+  AddRes      : Δ ⊢T NumRes → Δ ⊢T NumRes → Δ ⊢T NumRes → Δ ⊢T Type
+  MulRes      : Δ ⊢T NumRes → Δ ⊢T NumRes → Δ ⊢T NumRes → Δ ⊢T Type
+  
+  BoolRes  : BoolRestriction → Δ ⊢T BoolRes
+  BoolConstRes : Δ ⊢T BoolRes → Δ ⊢T Type
+  NotRes       : Δ ⊢T BoolRes → Δ ⊢T BoolRes → Δ ⊢T Type
+  AndRes       : Δ ⊢T BoolRes → Δ ⊢T BoolRes → Δ ⊢T BoolRes → Δ ⊢T Type
+  OrRes        : Δ ⊢T BoolRes → Δ ⊢T BoolRes → Δ ⊢T BoolRes → Δ ⊢T Type
+  LeqRes       : Δ ⊢T NumRes → Δ ⊢T NumRes → Δ ⊢T BoolRes → Δ ⊢T Type
+  QuantRes     : Δ ⊢T NumRes → Δ ⊢T BoolRes → Δ ⊢T BoolRes → Δ ⊢T Type
+  IfRes        : Δ ⊢T BoolRes → Δ ⊢T Type
 
 ren-Type : ∀ {K₁ K₂ κ} → (K₂ ⇒ᵣ K₁) → K₁ ⊢T κ → K₂ ⊢T κ
 ren-Type ρ (var x) = var (ρ x)
-ren-Type ρ (Bool l x) = Bool (ren-Type ρ l) (ren-Type ρ x)
-ren-Type ρ (Num x) = Num (ren-Type ρ x)
+ren-Type ρ (Bool r) = Bool (ren-Type ρ r)
+ren-Type ρ (Num r) = Num (ren-Type ρ r)
 ren-Type ρ (A ⇒ B) = (ren-Type ρ A) ⇒ (ren-Type ρ B)
 ren-Type ρ (Index A) = Index (ren-Type ρ A)
 ren-Type ρ (Vec A B) = Vec (ren-Type ρ A) (ren-Type ρ B)
 ren-Type ρ (Forall s A) = Forall s (ren-Type (under ρ) A)
 ren-Type ρ [ n ] = [ n ]
-ren-Type ρ (LinearityConst l) = LinearityConst l
-ren-Type ρ (PolarityConst p) = PolarityConst p
-ren-Type ρ (MaxLin l₁ l₂ l₃) = MaxLin (ren-Type ρ l₁) (ren-Type ρ l₂) (ren-Type ρ l₃)
-ren-Type ρ (MaxPol p₁ p₂ p₃) = MaxPol (ren-Type ρ p₁) (ren-Type ρ p₂) (ren-Type ρ p₃)
-ren-Type ρ (HasMul l₁ l₂ l₃) = HasMul (ren-Type ρ l₁) (ren-Type ρ l₂) (ren-Type ρ l₃)
-ren-Type ρ (NegPol p₁ p₂)  = NegPol (ren-Type ρ p₁) (ren-Type ρ p₂)
-ren-Type ρ (Quantify p₁ p₂)  = Quantify (ren-Type ρ p₁) (ren-Type ρ p₂)
+-- Number restrictions
+ren-Type ρ (NumRes l) = NumRes l
+ren-Type ρ (NumConstRes l) = NumConstRes (ren-Type ρ l)
+ren-Type ρ (FuncRes l₁ l₂) = FuncRes (ren-Type ρ l₁) (ren-Type ρ l₂)
+ren-Type ρ (AddRes l₁ l₂ l₃) = AddRes (ren-Type ρ l₁) (ren-Type ρ l₂) (ren-Type ρ l₃)
+ren-Type ρ (MulRes l₁ l₂ l₃) = MulRes (ren-Type ρ l₁) (ren-Type ρ l₂) (ren-Type ρ l₃)
+-- Bool restrictions
+ren-Type ρ (BoolRes p) = BoolRes p
+ren-Type ρ (BoolConstRes p) = BoolConstRes (ren-Type ρ p)
+ren-Type ρ (AndRes p₁ p₂ p₃) = AndRes (ren-Type ρ p₁) (ren-Type ρ p₂) (ren-Type ρ p₃)
+ren-Type ρ (OrRes p₁ p₂ p₃) = OrRes (ren-Type ρ p₁) (ren-Type ρ p₂) (ren-Type ρ p₃)
+ren-Type ρ (LeqRes p₁ p₂ p₃) = LeqRes (ren-Type ρ p₁) (ren-Type ρ p₂) (ren-Type ρ p₃)
+ren-Type ρ (NotRes p₁ p₂)  = NotRes (ren-Type ρ p₁) (ren-Type ρ p₂)
+ren-Type ρ (QuantRes l p₁ p₂)  = QuantRes (ren-Type ρ l) (ren-Type ρ p₁) (ren-Type ρ p₂)
+ren-Type ρ (IfRes p)  = IfRes (ren-Type ρ p)
+
 
 _⇒ₛ_ : KindContext → KindContext → Set
 K₁ ⇒ₛ K₂ = ∀ {κ} → K₂ ⊢Tv κ → K₁ ⊢T κ
@@ -81,115 +100,128 @@ binder σ (succ x) = ren-Type wk (σ x)
 
 subst-Type : ∀ {K₁ K₂} → (K₂ ⇒ₛ K₁) → ∀ {κ} → K₁ ⊢T κ → K₂ ⊢T κ
 subst-Type σ (var x) = σ x
-subst-Type σ (Bool l x) = Bool (subst-Type σ l) (subst-Type σ x)
-subst-Type σ (Num x) = Num (subst-Type σ x)
+subst-Type σ (Bool r) = Bool (subst-Type σ r)
+subst-Type σ (Num r) = Num (subst-Type σ r)
 subst-Type σ (A ⇒ B) = (subst-Type σ A) ⇒ (subst-Type σ B)
 subst-Type σ (Index A) = Index (subst-Type σ A)
 subst-Type σ (Vec A B) = Vec (subst-Type σ A) (subst-Type σ B)
 subst-Type σ (Forall s A) = Forall s (subst-Type (binder σ) A)
 subst-Type σ [ n ] = [ n ]
-subst-Type σ (LinearityConst l) = LinearityConst l
-subst-Type σ (PolarityConst l) = PolarityConst l
-subst-Type σ (MaxLin l₁ l₂ l₃) = MaxLin (subst-Type σ l₁) (subst-Type σ l₂) (subst-Type σ l₃)
-subst-Type σ (MaxPol p₁ p₂ p₃) = MaxPol (subst-Type σ p₁) (subst-Type σ p₂) (subst-Type σ p₃)
-subst-Type σ (HasMul l₁ l₂ l₃) = HasMul (subst-Type σ l₁) (subst-Type σ l₂) (subst-Type σ l₃)
-subst-Type σ (NegPol p₁ p₂)    = NegPol (subst-Type σ p₁) (subst-Type σ p₂)
-subst-Type σ (Quantify p₁ p₂)  = Quantify (subst-Type σ p₁) (subst-Type σ p₂)
+-- Number restrictions
+subst-Type σ (NumRes l) = NumRes l
+subst-Type σ (NumConstRes l) = NumConstRes (subst-Type σ l)
+subst-Type σ (FuncRes l₁ l₂) = FuncRes (subst-Type σ l₁) (subst-Type σ l₂)
+subst-Type σ (AddRes l₁ l₂ l₃) = AddRes (subst-Type σ l₁) (subst-Type σ l₂) (subst-Type σ l₃)
+subst-Type σ (MulRes l₁ l₂ l₃) = MulRes (subst-Type σ l₁) (subst-Type σ l₂) (subst-Type σ l₃)
+-- Bool restrictions
+subst-Type σ (BoolRes p) = BoolRes p
+subst-Type σ (BoolConstRes p) = BoolConstRes (subst-Type σ p)
+subst-Type σ (AndRes p₁ p₂ p₃) = AndRes (subst-Type σ p₁) (subst-Type σ p₂) (subst-Type σ p₃)
+subst-Type σ (OrRes p₁ p₂ p₃) = OrRes (subst-Type σ p₁) (subst-Type σ p₂) (subst-Type σ p₃)
+subst-Type σ (LeqRes p₁ p₂ p₃) = LeqRes (subst-Type σ p₁) (subst-Type σ p₂) (subst-Type σ p₃)
+subst-Type σ (NotRes p₁ p₂)  = NotRes (subst-Type σ p₁) (subst-Type σ p₂)
+subst-Type σ (QuantRes l p₁ p₂)  = QuantRes (subst-Type σ l) (subst-Type σ p₁) (subst-Type σ p₂)
+subst-Type σ (IfRes p)  = IfRes (subst-Type σ p)
 
 single-sub : ∀ {K κ} → K ⊢T κ → K ⇒ₛ (K ,- κ)
 single-sub N zero = N
 single-sub N (succ x) = var x
 
 data Context : KindContext → Set where
-  ε    : ∀ {Δ} → Context Δ
-  _,-_ : ∀ {Δ} → Context Δ → Δ ⊢T Type → Context Δ
+  ε    : Context Δ
+  _,-_ : Context Δ → Δ ⊢T Type → Context Δ
 
 infixl 10 _,-_
+
+private variable Γ : Context Δ
 
 ren-Context : ∀ {K₁ K₂} → (K₂ ⇒ᵣ K₁) → Context K₁ → Context K₂
 ren-Context ρ ε        = ε
 ren-Context ρ (Γ ,- A) = (ren-Context ρ Γ) ,- ren-Type ρ A
 
 data _⊢_∋_ : (Δ : KindContext) → Context Δ → Δ ⊢T Type → Set where
-  zero : ∀ {Δ Γ A}   →             Δ ⊢ (Γ ,- A) ∋ A
-  succ : ∀ {Δ Γ A B} → Δ ⊢ Γ ∋ A → Δ ⊢ (Γ ,- B) ∋ A
-
+  zero : ∀ {A}   →             Δ ⊢ (Γ ,- A) ∋ A
+  succ : ∀ {A B} → Δ ⊢ Γ ∋ A → Δ ⊢ (Γ ,- B) ∋ A
+  
 data _/_⊢_ : (Δ : KindContext) → Context Δ → Δ ⊢T Type → Set where
   -- Variables
-  var    : ∀ {Δ Γ A} → Δ ⊢ Γ ∋ A → Δ / Γ ⊢ A
+  var    : ∀ {A} → Δ ⊢ Γ ∋ A → Δ / Γ ⊢ A
 
   -- Functions
-  ƛ      : ∀ {Δ Γ A B} →
+  ƛ      : ∀ {A B} →
            Δ / (Γ ,- A) ⊢ B →
            Δ / Γ ⊢ (A ⇒ B)
-  _∙_    : ∀ {Δ Γ A B} →
+  _∙_    : ∀ {A B} →
            Δ / Γ ⊢ (A ⇒ B) →
            Δ / Γ ⊢ A →
            Δ / Γ ⊢ B
 
   -- Type quantification
-  Λ      : ∀ {Δ Γ κ A} →
+  Λ      : ∀ {κ A} →
            (s : SmallKind κ) →
            (Δ ,- κ) / (ren-Context wk Γ) ⊢ A →
            Δ / Γ ⊢ Forall s A
-  _•_    : ∀ {Δ Γ κ s A} →
+  _•_    : ∀ {κ s A} →
            Δ / Γ ⊢ Forall s A →
            (B : Δ ⊢T κ) →
            Δ / Γ ⊢ subst-Type (single-sub B) A
 
   -- External functions
-  func   : ∀ {Δ Γ} → Δ / Γ ⊢ Num (LinearityConst linear) → Δ / Γ ⊢ Num (LinearityConst linear)
+  func   : ∀ {r₁ r₂} → Δ / Γ ⊢ FuncRes r₁ r₂ → Δ / Γ ⊢ Num r₁ → Δ / Γ ⊢ Num r₂
 
-  const  : ∀ {Δ Γ} → ℚ → Δ / Γ ⊢ Num (LinearityConst const)
-  _`+_   : ∀ {Δ Γ l₁ l₂ l₃} → Δ / Γ ⊢ MaxLin l₁ l₂ l₃ → Δ / Γ ⊢ Num l₁ → Δ / Γ ⊢ Num l₂ → Δ / Γ ⊢ Num l₃
-  _`*_   : ∀ {Δ Γ l₁ l₂ l₃} → Δ / Γ ⊢ HasMul l₁ l₂ l₃ → Δ / Γ ⊢ Num l₁ → Δ / Γ ⊢ Num l₂ → Δ / Γ ⊢ Num l₃
+  const  : ∀ {r₁} → Δ / Γ ⊢ NumConstRes r₁ → ℚ → Δ / Γ ⊢ Num r₁
+  _`+_   : ∀ {l₁ l₂ l₃} → Δ / Γ ⊢ AddRes l₁ l₂ l₃ → Δ / Γ ⊢ Num l₁ → Δ / Γ ⊢ Num l₂ → Δ / Γ ⊢ Num l₃
+  _`*_   : ∀ {l₁ l₂ l₃} → Δ / Γ ⊢ MulRes l₁ l₂ l₃ → Δ / Γ ⊢ Num l₁ → Δ / Γ ⊢ Num l₂ → Δ / Γ ⊢ Num l₃
 
   -- Vecs
-  foreach : ∀ {Δ Γ} → (n : Δ ⊢T Nat) (A : Δ ⊢T Type) → Δ / (Γ ,- Index n) ⊢ A → Δ / Γ ⊢ Vec n A
-  index   : ∀ {Δ Γ} → (n : Δ ⊢T Nat) (A : Δ ⊢T Type) → Δ / Γ ⊢ Vec n A → Δ / Γ ⊢ Index n → Δ / Γ ⊢ A
-  idx     : ∀ {Δ Γ n} → (i : Fin n) → Δ / Γ ⊢ Index [ n ]
+  foreach : (n : Δ ⊢T Nat) (A : Δ ⊢T Type) → Δ / (Γ ,- Index n) ⊢ A → Δ / Γ ⊢ Vec n A
+  index   : (n : Δ ⊢T Nat) (A : Δ ⊢T Type) → Δ / Γ ⊢ Vec n A → Δ / Γ ⊢ Index n → Δ / Γ ⊢ A
+  idx     : ∀ {n} → (i : Fin n) → Δ / Γ ⊢ Index [ n ]
   -- FIXME: crush/fold/reduce
 
   -- Comparisons
-  _`≤_   : ∀ {Δ Γ l₁ l₂ l₃} → Δ / Γ ⊢ MaxLin l₁ l₂ l₃ → Δ / Γ ⊢ Num l₁ → Δ / Γ ⊢ Num l₂ → Δ / Γ ⊢ Bool l₃ (PolarityConst U)
+  _`≤_   : ∀ {l₁ l₂ l₃} → Δ / Γ ⊢ LeqRes l₁ l₂ l₃ → Δ / Γ ⊢ Num l₁ → Δ / Γ ⊢ Num l₂ → Δ / Γ ⊢ Bool l₃
 
   -- Polymorphic if-then-else
-  if_then_else_ : ∀ {Δ Γ A}
-     (cond : Δ / Γ ⊢ Bool (LinearityConst linear) (PolarityConst U))
+  if_then_else_ : ∀ {A r₁} → Δ / Γ ⊢ IfRes r₁ → 
+     (cond : Δ / Γ ⊢ Bool r₁)
      (on-true on-false : Δ / Γ ⊢ A) →
      Δ / Γ ⊢ A
   -- FIXME: need an 'almost equal' typeclass constraint here; can make it as complex as needed
   -- Soundness counterexample: forall (x : Rat) . f 10 ! (if (x >= 7) then 0 else 1) == 0
 
   -- Logic
-  _`∧_ _`∨_ : ∀ {Δ Γ l₁ l₂ l₃ p₁ p₂ p₃} →
-            Δ / Γ ⊢ MaxLin l₁ l₂ l₃ →
-            Δ / Γ ⊢ MaxPol p₁ p₂ p₃ →
-            Δ / Γ ⊢ Bool l₁ p₁ →
-            Δ / Γ ⊢ Bool l₂ p₂ →
-            Δ / Γ ⊢ Bool l₃ p₃
-  `¬_ : ∀ {Δ Γ l p₁ p₂} →
-        Δ / Γ ⊢ NegPol p₁ p₂ →
-        Δ / Γ ⊢ Bool l p₁ →
-        Δ / Γ ⊢ Bool l p₂
-  ∃   : ∀ {Δ Γ p₁ p₂ l} →
-        Δ / Γ ⊢ Quantify p₁ p₂ →
-        Δ / Γ ⊢ (Num (LinearityConst linear) ⇒ Bool l p₁) →
-        Δ / Γ ⊢ Bool l p₂
+  _`∧_ : ∀ {r₁ r₂ r₃} → Δ / Γ ⊢ AndRes r₁ r₂ r₃ → Δ / Γ ⊢ Bool r₁ → Δ / Γ ⊢ Bool r₂ → Δ / Γ ⊢ Bool r₃
+  _`∨_ : ∀ {b₁ b₂ b₃} → Δ / Γ ⊢ OrRes b₁ b₂ b₃ → Δ / Γ ⊢ Bool b₁ →
+            Δ / Γ ⊢ Bool b₂ →
+            Δ / Γ ⊢ Bool b₃
+  `¬_ : ∀ {b₁ b₂} → Δ / Γ ⊢ NotRes b₁ b₂ → Δ / Γ ⊢ Bool b₁ →
+        Δ / Γ ⊢ Bool b₂
+  ∃   : ∀ {n₁ b₁ b₂} →
+        Δ / Γ ⊢ QuantRes n₁ b₁ b₂ →
+        Δ / Γ ⊢ (Num n₁ ⇒ Bool b₁) →
+        Δ / Γ ⊢ Bool b₂
 
   -- Evidence for usage of the operations
-  maxlin : ∀ {Δ Γ l₁ l₂ l₃} →
-           MaxLinRel l₁ l₂ l₃ →
-           Δ / Γ ⊢ MaxLin (LinearityConst l₁) (LinearityConst l₂) (LinearityConst l₃)
-  hasmul : ∀ {Δ Γ l₁ l₂ l₃} →
-           MulRel l₁ l₂ l₃ →
-           Δ / Γ ⊢ HasMul (LinearityConst l₁) (LinearityConst l₂) (LinearityConst l₃)
-  maxpol : ∀ {Δ Γ p₁ p₂ p₃} →
-           MaxPolRel p₁ p₂ p₃ →
-           Δ / Γ ⊢ MaxPol (PolarityConst p₁) (PolarityConst p₂) (PolarityConst p₃)
-  negpol : ∀ {Δ Γ p₁ p₂} →
-           NegPolRel p₁ p₂ →
-           Δ / Γ ⊢ NegPol (PolarityConst p₁) (PolarityConst p₂)
-  quantify : ∀ {Δ Γ p₁ p₂} →
-             QuantifyRel p₁ p₂ →
-             Δ / Γ ⊢ Quantify (PolarityConst p₁) (PolarityConst p₂)
+  numConstRes : ∀ {l} → NumConstRestriction l → Δ / Γ ⊢ NumConstRes (NumRes l)
+  funcRes : ∀ {l₁ l₂} → FuncRestriction l₁ l₂ → Δ / Γ ⊢ FuncRes (NumRes l₁) (NumRes l₂)
+  addRes : ∀ {l₁ l₂ l₃} →
+           AddRestriction l₁ l₂ l₃ →
+           Δ / Γ ⊢ AddRes (NumRes l₁) (NumRes l₂) (NumRes l₃)
+  mulRes : ∀ {l₁ l₂ l₃} →
+           MulRestriction l₁ l₂ l₃ →
+           Δ / Γ ⊢ MulRes (NumRes l₁) (NumRes l₂) (NumRes l₃)
+
+  boolConstRes : ∀ {b} → BoolConstRestriction b → Δ / Γ ⊢ BoolConstRes (BoolRes b)
+  notRes : ∀ {p₁ p₂} → NotRestriction p₁ p₂ →
+           Δ / Γ ⊢ NotRes (BoolRes p₁) (BoolRes p₂)
+  andRes : ∀ {p₁ p₂ p₃} → AndRestriction p₁ p₂ p₃ →
+           Δ / Γ ⊢ AndRes (BoolRes p₁) (BoolRes p₂) (BoolRes p₃)
+  orRes  : ∀ {p₁ p₂ p₃} → OrRestriction p₁ p₂ p₃ →
+           Δ / Γ ⊢ OrRes (BoolRes p₁) (BoolRes p₂) (BoolRes p₃)
+  leqRes : ∀ {n₁ n₂ b} → LeqRestriction n₁ n₂ b →
+           Δ / Γ ⊢ LeqRes (NumRes n₁) (NumRes n₂) (BoolRes b)
+  quantRes : ∀ {n p₁ p₂} → QuantRestriction n p₁ p₂ →
+             Δ / Γ ⊢ QuantRes (NumRes n) (BoolRes p₁) (BoolRes p₂)
+  ifRes : ∀ {b} → IfRestriction b →
+          Δ / Γ ⊢ IfRes (BoolRes b)

--- a/src/MiniVehicle/Qualifiers.agda
+++ b/src/MiniVehicle/Qualifiers.agda
@@ -2,22 +2,38 @@
 
 module MiniVehicle.Qualifiers where
 
+open import MiniVehicle.Restriction
+open import Data.Product
+
+-- Linearity restrictions
+
 data LinearityVal : Set where
   const linear nonlinear : LinearityVal
 
-data PolarityVal : Set where
-  U Ex : PolarityVal
-
+data NumConstRel : LinearityVal → Set where
+  const : NumConstRel const
+  
+data FuncRel : LinearityVal → LinearityVal → Set where
+  linear-linear : FuncRel linear linear
+  
 data MaxLinRel : LinearityVal → LinearityVal → LinearityVal → Set where
   const-const   : MaxLinRel const const const
   const-linear  : MaxLinRel const linear linear
   linear-const  : MaxLinRel linear const linear
   linear-linear : MaxLinRel linear linear linear
 
-data MulRel : LinearityVal → LinearityVal → LinearityVal → Set where
-  const-const  : MulRel const const const
-  const-linear : MulRel const linear linear
-  linear-const : MulRel linear const linear
+data MulLinRel : LinearityVal → LinearityVal → LinearityVal → Set where
+  const-const  : MulLinRel const const const
+  const-linear : MulLinRel const linear linear
+  linear-const : MulLinRel linear const linear
+
+-- Polarity
+
+data PolarityVal : Set where
+  U Ex : PolarityVal
+
+data ConstPolRel : PolarityVal → Set where
+  U : ConstPolRel U
 
 data MaxPolRel : PolarityVal → PolarityVal → PolarityVal → Set where
   U-U   : MaxPolRel U U U
@@ -31,3 +47,45 @@ data NegPolRel : PolarityVal → PolarityVal → Set where
 data QuantifyRel : PolarityVal → PolarityVal → Set where
   U  : QuantifyRel U Ex
   Ex : QuantifyRel Ex Ex
+
+
+-- Restrictions
+
+data BoolConstRel : LinearityVal × PolarityVal → Set where
+  U : BoolConstRel (const , U)
+  
+data MaxBoolRes : LinearityVal × PolarityVal → LinearityVal × PolarityVal → LinearityVal × PolarityVal → Set where
+  maxBoolRes : ∀ {l₁ l₂ l₃ p₁ p₂ p₃} → MaxLinRel l₁ l₂ l₃ → MaxPolRel p₁ p₂ p₃ → MaxBoolRes (l₁ , p₁) (l₂ , p₂) (l₃ , p₃)
+
+data NotRes : LinearityVal × PolarityVal → LinearityVal × PolarityVal → Set where
+  notRes : ∀ {l p₁ p₂} → NegPolRel p₁ p₂ → NotRes (l , p₁) (l , p₂)
+
+data LeqRes : LinearityVal → LinearityVal → LinearityVal × PolarityVal → Set where
+  leqRes : ∀ {l₁ l₂ l₃} → MaxLinRel l₁ l₂ l₃ → LeqRes l₁ l₂ (l₃ , U) 
+
+data IfRes : LinearityVal × PolarityVal → Set where
+  ifRes : ∀ l → IfRes (l , U)
+
+data QuantRes : LinearityVal → LinearityVal × PolarityVal → LinearityVal × PolarityVal → Set where
+  quantRes : ∀ {l p₁ p₂} → QuantifyRel p₁ p₂ → QuantRes linear (l , p₁) (l , p₂)
+  
+-- Restrictions
+
+verifierRestriction : SyntaxRestriction
+verifierRestriction = record
+  { NumRestriction  = LinearityVal
+  ; BoolRestriction = LinearityVal × PolarityVal
+
+  ; BoolConstRestriction = BoolConstRel
+  ; AndRestriction = MaxBoolRes
+  ; OrRestriction  = MaxBoolRes
+  ; NotRestriction = NotRes
+  ; LeqRestriction = LeqRes
+  ; QuantRestriction = QuantRes
+  ; IfRestriction = IfRes
+  
+  ; NumConstRestriction = NumConstRel
+  ; FuncRestriction = FuncRel
+  ; AddRestriction = MaxLinRel
+  ; MulRestriction = MulLinRel
+  }

--- a/src/MiniVehicle/Restriction.agda
+++ b/src/MiniVehicle/Restriction.agda
@@ -1,0 +1,23 @@
+{-# OPTIONS --postfix-projections --safe #-}
+
+module MiniVehicle.Restriction where
+
+-- This record type is used to instatiate restrictions on the syntax of mini-vehicle
+-- depending on the appropriate backend targetted. For example, the verifier backend
+-- can only handle linear expressions with non-alternating quantifiers.
+record SyntaxRestriction : Set₁ where
+  field
+    NumRestriction : Set
+    NumConstRestriction : NumRestriction → Set
+    FuncRestriction : NumRestriction → NumRestriction → Set
+    AddRestriction : NumRestriction → NumRestriction → NumRestriction → Set
+    MulRestriction : NumRestriction → NumRestriction → NumRestriction → Set
+
+    BoolRestriction : Set
+    BoolConstRestriction : BoolRestriction → Set
+    NotRestriction : BoolRestriction → BoolRestriction → Set
+    AndRestriction : BoolRestriction → BoolRestriction → BoolRestriction → Set
+    OrRestriction : BoolRestriction → BoolRestriction → BoolRestriction → Set
+    LeqRestriction : NumRestriction → NumRestriction → BoolRestriction → Set
+    QuantRestriction : NumRestriction → BoolRestriction → BoolRestriction → Set
+    IfRestriction : BoolRestriction → Set

--- a/src/Normalisation.agda
+++ b/src/Normalisation.agda
@@ -31,11 +31,11 @@ open _==>_ public
 Flat : Set → Syn
 Flat = K
 
-⟦Bool⟧ : LinearityVal → PolarityVal → Syn
-⟦Bool⟧ _ Ex .Carrier = ExFormula
-⟦Bool⟧ _ Ex .rename = rename-ExFormula
-⟦Bool⟧ _ U .Carrier = Constraint
-⟦Bool⟧ _ U .rename = rename-Constraint
+⟦Bool⟧ : LinearityVal × PolarityVal → Syn
+⟦Bool⟧ (_ , Ex) .Carrier = ExFormula
+⟦Bool⟧ (_ , Ex) .rename = rename-ExFormula
+⟦Bool⟧ (_ , U) .Carrier = Constraint
+⟦Bool⟧ (_ , U) .rename = rename-Constraint
 
 ⟦Num⟧ : LinearityVal → Syn
 ⟦Num⟧ const = K ℚ
@@ -137,58 +137,58 @@ _∘S_ : ∀ {X Y Z} → (Y ==> Z) → (X ==> Y) → (X ==> Z)
 ⟦add⟧ .mor (linear-const , x , y) = x `+` const y
 ⟦add⟧ .mor (linear-linear , x , y) = x `+` y
 
-⟦mul⟧ : ∀ {l₁ l₂ l₃} → (Flat (MulRel l₁ l₂ l₃) ⟦×⟧ (⟦Num⟧ l₁ ⟦×⟧ ⟦Num⟧ l₂)) ==> ⟦Num⟧ l₃
+⟦mul⟧ : ∀ {l₁ l₂ l₃} → (Flat (MulLinRel l₁ l₂ l₃) ⟦×⟧ (⟦Num⟧ l₁ ⟦×⟧ ⟦Num⟧ l₂)) ==> ⟦Num⟧ l₃
 ⟦mul⟧ .mor (const-const , x , y) = x * y
 ⟦mul⟧ .mor (const-linear , x , y) = x ⊛ y
 ⟦mul⟧ .mor (linear-const , x , y) = y ⊛ x
 
-⟦≤⟧ : ∀ {l₁ l₂ l₃} → (Flat (MaxLinRel l₁ l₂ l₃) ⟦×⟧ (⟦Num⟧ l₁ ⟦×⟧ ⟦Num⟧ l₂)) ==> ⟦Bool⟧ l₃ U
-⟦≤⟧ .mor (const-const ,   x , y) = const x `≤` const y
-⟦≤⟧ .mor (const-linear ,  x , y) = const x `≤` y
-⟦≤⟧ .mor (linear-const ,  x , y) = x `≤` const y
-⟦≤⟧ .mor (linear-linear , x , y) = x `≤` y
+⟦≤⟧ : ∀ {l₁ l₂ l₃} → (Flat (LeqRes l₁ l₂ l₃) ⟦×⟧ (⟦Num⟧ l₁ ⟦×⟧ ⟦Num⟧ l₂)) ==> ⟦Bool⟧ l₃
+⟦≤⟧ .mor (leqRes const-const ,   x , y) = const x `≤` const y
+⟦≤⟧ .mor (leqRes const-linear ,  x , y) = const x `≤` y
+⟦≤⟧ .mor (leqRes linear-const ,  x , y) = x `≤` const y
+⟦≤⟧ .mor (leqRes linear-linear , x , y) = x `≤` y
 
-⟦not⟧ : ∀ {l p₁ p₂} → (Flat (NegPolRel p₁ p₂) ⟦×⟧ ⟦Bool⟧ l p₁) ==> ⟦Bool⟧ l p₂
-⟦not⟧ .mor (U , x) = negate x
+⟦not⟧ : ∀ {p₁ p₂} → (Flat (NotRes p₁ p₂) ⟦×⟧ ⟦Bool⟧ p₁) ==> ⟦Bool⟧ p₂
+⟦not⟧ .mor (notRes U , x) = negate x
 
-⟦and⟧ : ∀ {l₁ l₂ l₃ p₁ p₂ p₃} →
-         (Flat (MaxLinRel l₁ l₂ l₃) ⟦×⟧
-          (Flat (MaxPolRel p₁ p₂ p₃) ⟦×⟧
-           (⟦Bool⟧ l₁ p₁ ⟦×⟧ ⟦Bool⟧ l₂ p₂))) ==> ⟦Bool⟧ l₃ p₃
-⟦and⟧ .mor (p , U-U ,   x , y) = x and y
-⟦and⟧ .mor (p , U-Ex ,  x , y) = constraint x and y
-⟦and⟧ .mor (p , Ex-U ,  x , y) = x and constraint y
-⟦and⟧ .mor (p , Ex-Ex , x , y) = x and y
+⟦and⟧ : ∀ {l₁ l₂ l₃} →
+         (Flat (MaxBoolRes l₁ l₂ l₃) ⟦×⟧
+           (⟦Bool⟧ l₁ ⟦×⟧ ⟦Bool⟧ l₂)) ==> ⟦Bool⟧ l₃
+⟦and⟧ .mor (maxBoolRes _ U-U ,   x , y) = x and y
+⟦and⟧ .mor (maxBoolRes _ U-Ex ,  x , y) = constraint x and y
+⟦and⟧ .mor (maxBoolRes _ Ex-U ,  x , y) = x and constraint y
+⟦and⟧ .mor (maxBoolRes _ Ex-Ex , x , y) = x and y
 
-⟦or⟧ : ∀ {l₁ l₂ l₃ p₁ p₂ p₃} →
-         (Flat (MaxLinRel l₁ l₂ l₃) ⟦×⟧
-          (Flat (MaxPolRel p₁ p₂ p₃) ⟦×⟧
-           (⟦Bool⟧ l₁ p₁ ⟦×⟧ ⟦Bool⟧ l₂ p₂))) ==> ⟦Bool⟧ l₃ p₃
-⟦or⟧ .mor (p , U-U ,   x , y) = x or y
-⟦or⟧ .mor (p , U-Ex ,  x , y) = constraint x or y
-⟦or⟧ .mor (p , Ex-U ,  x , y) = x or constraint y
-⟦or⟧ .mor (p , Ex-Ex , x , y) = x or y
+⟦or⟧ : ∀ {l₁ l₂ l₃} →
+         (Flat (MaxBoolRes l₁ l₂ l₃) ⟦×⟧
+           (⟦Bool⟧ l₁ ⟦×⟧ ⟦Bool⟧ l₂)) ==> ⟦Bool⟧ l₃
+⟦or⟧ .mor (maxBoolRes _ U-U ,   x , y) = x or y
+⟦or⟧ .mor (maxBoolRes _ U-Ex ,  x , y) = constraint x or y
+⟦or⟧ .mor (maxBoolRes _ Ex-U ,  x , y) = x or constraint y
+⟦or⟧ .mor (maxBoolRes _ Ex-Ex , x , y) = x or y
 
-⟦const⟧ : ∀ {X} → ℚ → X ==> ⟦Num⟧ const
-⟦const⟧ q .mor _ = q
+⟦const⟧ : ∀ {l} → ℚ → Flat (NumConstRel l) ==> ⟦Num⟧ l
+⟦const⟧ q .mor const = q
 
-⟦extFunc⟧ : ⟦Num⟧ linear ==> LiftM (⟦Num⟧ linear)
-⟦extFunc⟧ .mor exp =
+⟦extFunc⟧ : ∀ {l₁ l₂} → (Flat (FuncRel l₁ l₂) ⟦×⟧ (⟦Num⟧ l₁)) ==> LiftM (⟦Num⟧ l₂)
+⟦extFunc⟧ .mor (linear-linear , exp) =
   let-linexp exp (let-funexp {- f -} zero (return (var 1ℚ zero)))
 
-⟦if⟧ : ∀ {X} → ((LiftM X ⟦×⟧ LiftM X) ⟦×⟧ ⟦Bool⟧ linear U) ==> LiftM X
-⟦if⟧ .mor ((tr , fa) , ϕ)= if ϕ tr fa
+⟦if⟧ : ∀ {X b} → ((LiftM X ⟦×⟧ LiftM X) ⟦×⟧ (Flat (IfRes b) ⟦×⟧ (⟦Bool⟧ b))) ==> LiftM X
+⟦if⟧ .mor ((tr , fa) , (ifRes _ , ϕ)) = if ϕ tr fa
 
 ⟦Index⟧ : ℕ → Syn
 ⟦Index⟧ n = K (Fin n)
 
-⟦∃⟧ : ∀ {p₁ p₂ l} →
-     (Flat (QuantifyRel p₁ p₂) ⟦×⟧ (⟦Num⟧ linear ⟦⇒⟧ LiftM (⟦Bool⟧ l p₁))) ==> ⟦Bool⟧ l p₂
-⟦∃⟧ .mor {Δ} (U , f) = ex (compile (bind-let (f (Δ ,∙) succ (var 1ℚ zero))
+⟦∃⟧ : ∀ {l p₁ p₂} →
+     (Flat (QuantRes l p₁ p₂) ⟦×⟧ (⟦Num⟧ l ⟦⇒⟧ LiftM (⟦Bool⟧ p₁))) ==> ⟦Bool⟧ p₂
+⟦∃⟧ .mor {Δ} (quantRes U , f) =
+  ex (compile (bind-let (f (Δ ,∙) succ (var 1ℚ zero))
                                      λ Δ' ρ ϕ → return (constraint ϕ)))
-⟦∃⟧ .mor {Δ} (Ex , f) = ex (compile (f (Δ ,∙) succ (var 1ℚ zero)))
+⟦∃⟧ .mor {Δ} (quantRes Ex , f) = 
+  ex (compile (f (Δ ,∙) succ (var 1ℚ zero)))
 
-ℳ : Model (suc 0ℓ) 0ℓ
+ℳ : Model verifierRestriction (suc 0ℓ) 0ℓ
 ℳ .Model.⟦Type⟧ = Syn
 ℳ .Model._==>_ = _==>_
 ℳ .Model.Flat = Flat
@@ -216,18 +216,20 @@ _∘S_ : ∀ {X Y Z} → (Y ==> Z) → (X ==> Y) → (X ==> Z)
 ℳ .Model.⟦const⟧ = ⟦const⟧
 ℳ .Model.⟦extFunc⟧ = ⟦extFunc⟧
 ℳ .Model.⟦Bool⟧ = ⟦Bool⟧
-ℳ .Model.⟦not⟧ {l} = ⟦not⟧ {l}
+ℳ .Model.⟦not⟧ = ⟦not⟧
 ℳ .Model.⟦and⟧ = ⟦and⟧
 ℳ .Model.⟦or⟧ = ⟦or⟧
 ℳ .Model.⟦≤⟧ = ⟦≤⟧
 ℳ .Model.⟦if⟧ = ⟦if⟧
 ℳ .Model.⟦Index⟧ = ⟦Index⟧
 ℳ .Model.⟦idx⟧ n i .mor _ = i
-ℳ .Model.⟦∃⟧ {l = l} = ⟦∃⟧ {l = l}
+ℳ .Model.⟦∃⟧ = ⟦∃⟧
 
-module 𝒩 = Interpret ℳ
+{-
+module 𝒩 = Interpret ? ℳ
 
 open import MiniVehicle
 
-normalise : ε / ε ⊢ Bool (LinearityConst linear) (PolarityConst Ex) → PrenexFormula ε
+normalise : ε / ε ⊢ Bool (BoolRes (linear , Ex)) → PrenexFormula ε
 normalise t = toPrenexForm (compile (𝒩.⟦ t ⟧tm (lift tt) .mor tt))
+-}

--- a/src/NormalisationCorrect.agda
+++ b/src/NormalisationCorrect.agda
@@ -86,6 +86,7 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
       ext   : ∀ {w w'} (ρ : w' ⇒w w) a b → rel w a b → rel w' a (Right .N.rename (ρ .ren) b)
   open WRel
 
+  infixr 20 _==>_
   record _==>_ (X Y : WRel) : Set where
     field
       left    : X .Left 𝒮.==> Y .Left
@@ -132,6 +133,7 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
   ⟦terminal⟧ .right = 𝒩.⟦terminal⟧
   ⟦terminal⟧ .rel-mor _ _ _ _ = tt
 
+  infixr 2 _⟦×⟧_
   _⟦×⟧_ : WRel → WRel → WRel
   (X ⟦×⟧ Y) .Left = X .Left 𝒮.⟦×⟧ Y .Left
   (X ⟦×⟧ Y) .Right = X .Right 𝒩.⟦×⟧ Y .Right
@@ -247,10 +249,10 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
   ⟦Num⟧ nonlinear .rel w x tt = ⊤
   ⟦Num⟧ nonlinear .ext _ _ _ _ = tt
 
-  ⟦const⟧ : ∀ {X} → ℚ → X ==> ⟦Num⟧ const
+  ⟦const⟧ : ∀ {l} → ℚ → Flat (NumConstRel l) ==> ⟦Num⟧ l
   ⟦const⟧ q .left _ = q
   ⟦const⟧ q .right = 𝒩.⟦const⟧ q
-  ⟦const⟧ q .rel-mor w _ _ _ = refl
+  ⟦const⟧ q .rel-mor w const const _ = refl
 
   ⟦add⟧ : ∀ {l₁ l₂ l₃} →
            (Flat (MaxLinRel l₁ l₂ l₃) ⟦×⟧ (⟦Num⟧ l₁ ⟦×⟧ ⟦Num⟧ l₂)) ==> ⟦Num⟧ l₃
@@ -265,7 +267,7 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
   ⟦add⟧ .rel-mor w (linear-linear , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
     cong₂ _+_ x₁₂ y₁₂
 
-  ⟦mul⟧ : ∀ {l₁ l₂ l₃} → (Flat (MulRel l₁ l₂ l₃) ⟦×⟧ (⟦Num⟧ l₁ ⟦×⟧ ⟦Num⟧ l₂)) ==> ⟦Num⟧ l₃
+  ⟦mul⟧ : ∀ {l₁ l₂ l₃} → (Flat (MulLinRel l₁ l₂ l₃) ⟦×⟧ (⟦Num⟧ l₁ ⟦×⟧ ⟦Num⟧ l₂)) ==> ⟦Num⟧ l₃
   ⟦mul⟧ .left = 𝒮.⟦mul⟧
   ⟦mul⟧ .right = 𝒩.⟦mul⟧
   ⟦mul⟧ .rel-mor w (const-const  , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
@@ -322,60 +324,59 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
   ext-ExFormula ρ _ _ (q-and r₁ r₂) = q-and (ext-ExFormula ρ _ _ r₁) (ext-ExFormula ρ _ _ r₂)
   ext-ExFormula ρ _ _ (q-or r₁ r₂) = q-or (ext-ExFormula ρ _ _ r₁) (ext-ExFormula ρ _ _ r₂)
 
-  ⟦Bool⟧ : LinearityVal → PolarityVal → WRel
-  ⟦Bool⟧ l p .Left = 𝒮.⟦Bool⟧ l p
-  ⟦Bool⟧ l p .Right = 𝒩.⟦Bool⟧ l p
-  ⟦Bool⟧ l U .rel w b ϕ = b ≡ eval-Constraint ϕ (w .env)
-  ⟦Bool⟧ l U .ext ρ b ϕ eq = trans eq (ext-evalConstraint ϕ ρ)
-  ⟦Bool⟧ l Ex .rel = ExFormulaR
-  ⟦Bool⟧ l Ex .ext = ext-ExFormula
+  ⟦Bool⟧ : LinearityVal × PolarityVal → WRel
+  ⟦Bool⟧ (l , p) .Left = 𝒮.⟦Bool⟧ (l , p)
+  ⟦Bool⟧ (l , p) .Right = 𝒩.⟦Bool⟧ (l , p)
+  ⟦Bool⟧ (l , U) .rel w b ϕ = b ≡ eval-Constraint ϕ (w .env)
+  ⟦Bool⟧ (l , U) .ext ρ b ϕ eq = trans eq (ext-evalConstraint ϕ ρ)
+  ⟦Bool⟧ (l , Ex) .rel = ExFormulaR
+  ⟦Bool⟧ (l , Ex) .ext = ext-ExFormula
 
-  ⟦≤⟧ : ∀ {l₁ l₂ l₃} → (Flat (MaxLinRel l₁ l₂ l₃) ⟦×⟧ (⟦Num⟧ l₁ ⟦×⟧ ⟦Num⟧ l₂)) ==> ⟦Bool⟧ l₃ U
+  ⟦≤⟧ : ∀ {l₁ l₂ l₃} → (Flat (LeqRes l₁ l₂ l₃) ⟦×⟧ (⟦Num⟧ l₁ ⟦×⟧ ⟦Num⟧ l₂)) ==> ⟦Bool⟧ l₃
   ⟦≤⟧ .left = 𝒮.⟦≤⟧
   ⟦≤⟧ .right = 𝒩.⟦≤⟧
-  ⟦≤⟧ .rel-mor w (const-const   , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
+  ⟦≤⟧ .rel-mor w (leqRes const-const   , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
     cong₂ _≤ᵇ_ x₁₂ y₁₂
-  ⟦≤⟧ .rel-mor w (const-linear  , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
+  ⟦≤⟧ .rel-mor w (leqRes const-linear  , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
     cong₂ _≤ᵇ_ x₁₂ y₁₂
-  ⟦≤⟧ .rel-mor w (linear-const  , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
+  ⟦≤⟧ .rel-mor w (leqRes linear-const  , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
     cong₂ _≤ᵇ_ x₁₂ y₁₂
-  ⟦≤⟧ .rel-mor w (linear-linear , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
+  ⟦≤⟧ .rel-mor w (leqRes linear-linear , x₁ , y₁) (_ , x₂ , y₂) (refl , x₁₂ , y₁₂) =
     cong₂ _≤ᵇ_ x₁₂ y₁₂
 
-  ⟦and⟧ : ∀ {l₁ l₂ l₃ p₁ p₂ p₃} →
-            (Flat (MaxLinRel l₁ l₂ l₃) ⟦×⟧
-             (Flat (MaxPolRel p₁ p₂ p₃) ⟦×⟧
-              (⟦Bool⟧ l₁ p₁ ⟦×⟧ ⟦Bool⟧ l₂ p₂))) ==> ⟦Bool⟧ l₃ p₃
+  ⟦and⟧ : ∀ {l₁ l₂ l₃} →
+            (Flat (MaxBoolRes l₁ l₂ l₃) ⟦×⟧
+              (⟦Bool⟧ l₁ ⟦×⟧ ⟦Bool⟧ l₂)) ==> ⟦Bool⟧ l₃
   ⟦and⟧ .left = 𝒮.⟦and⟧
   ⟦and⟧ .right = 𝒩.⟦and⟧
-  ⟦and⟧ .rel-mor w (p , U-U , x₁ , y₁) (_ , _ , x₂ , y₂) (refl , refl , x₁₂ , y₁₂) =
+  ⟦and⟧ .rel-mor w (maxBoolRes _ U-U , _) (maxBoolRes _ U-U , _) (eq , x₁₂ , y₁₂) =
     cong₂ _∧_ x₁₂ y₁₂
-  ⟦and⟧ .rel-mor w (p , U-Ex , x₁ , y₁) (_ , _ , x₂ , y₂) (refl , refl , x₁₂ , y₁₂) =
+  ⟦and⟧ .rel-mor w (maxBoolRes _ U-Ex , _) (maxBoolRes _ U-Ex , _) (_ , x₁₂ , y₁₂) =
     q-and (q-constraint (sym x₁₂)) y₁₂
-  ⟦and⟧ .rel-mor w (p , Ex-U , x₁ , y₁) (_ , _ , x₂ , y₂) (refl , refl , x₁₂ , y₁₂) =
+  ⟦and⟧ .rel-mor w (maxBoolRes _ Ex-U , _) (maxBoolRes _ Ex-U , _) (_ , x₁₂ , y₁₂) =
     q-and x₁₂ (q-constraint (sym y₁₂))
-  ⟦and⟧ .rel-mor w (p , Ex-Ex , x₁ , y₁) (_ , _ , x₂ , y₂) (refl , refl , x₁₂ , y₁₂) =
+  ⟦and⟧ .rel-mor w (maxBoolRes _ Ex-Ex , _) (maxBoolRes _ Ex-Ex , _) (_ ,  x₁₂ , y₁₂) =
     q-and x₁₂ y₁₂
 
-  ⟦or⟧ : ∀ {l₁ l₂ l₃ p₁ p₂ p₃} →
-            (Flat (MaxLinRel l₁ l₂ l₃) ⟦×⟧
-             (Flat (MaxPolRel p₁ p₂ p₃) ⟦×⟧
-              (⟦Bool⟧ l₁ p₁ ⟦×⟧ ⟦Bool⟧ l₂ p₂))) ==> ⟦Bool⟧ l₃ p₃
+  ⟦or⟧ : ∀ {l₁ l₂ l₃} →
+            (Flat (MaxBoolRes l₁ l₂ l₃) ⟦×⟧
+              (⟦Bool⟧ l₁ ⟦×⟧ ⟦Bool⟧ l₂)) ==> ⟦Bool⟧ l₃
   ⟦or⟧ .left = 𝒮.⟦or⟧
   ⟦or⟧ .right = 𝒩.⟦or⟧
-  ⟦or⟧ .rel-mor w (p , U-U , x₁ , y₁) (_ , _ , x₂ , y₂) (refl , refl , x₁₂ , y₁₂) =
+  ⟦or⟧ .rel-mor w (maxBoolRes _ U-U , _) (maxBoolRes _ U-U , _) (_ , x₁₂ , y₁₂) =
     cong₂ _∨_ x₁₂ y₁₂
-  ⟦or⟧ .rel-mor w (p , U-Ex , x₁ , y₁) (_ , _ , x₂ , y₂) (refl , refl , x₁₂ , y₁₂) =
+  ⟦or⟧ .rel-mor w (maxBoolRes _  U-Ex , _) (maxBoolRes _ U-Ex , _) (_ , x₁₂ , y₁₂) =
     q-or (q-constraint (sym x₁₂)) y₁₂
-  ⟦or⟧ .rel-mor w (p , Ex-U , x₁ , y₁) (_ , _ , x₂ , y₂) (refl , refl , x₁₂ , y₁₂) =
+  ⟦or⟧ .rel-mor w (maxBoolRes _  Ex-U , _) (maxBoolRes _ Ex-U , _) (_ , x₁₂ , y₁₂) =
     q-or x₁₂ (q-constraint (sym y₁₂))
-  ⟦or⟧ .rel-mor w (p , Ex-Ex , x₁ , y₁) (_ , _ , x₂ , y₂) (refl , refl , x₁₂ , y₁₂) =
+  ⟦or⟧ .rel-mor w (maxBoolRes _  Ex-Ex , _) (maxBoolRes _ Ex-Ex , _) (_ , x₁₂ , y₁₂) =
     q-or x₁₂ y₁₂
 
-  ⟦not⟧ : ∀ {l p₁ p₂} → (Flat (NegPolRel p₁ p₂) ⟦×⟧ ⟦Bool⟧ l p₁) ==> ⟦Bool⟧ l p₂
+
+  ⟦not⟧ : ∀ {p₁ p₂} → (Flat (NotRes p₁ p₂) ⟦×⟧ ⟦Bool⟧ p₁) ==> ⟦Bool⟧ p₂
   ⟦not⟧ .left = 𝒮.⟦not⟧
-  ⟦not⟧ {l} .right = 𝒩.⟦not⟧ {l = l}
-  ⟦not⟧ .rel-mor w (U , x₁) (_ , x₂) (refl , x₁₂) =
+  ⟦not⟧ .right = 𝒩.⟦not⟧
+  ⟦not⟧ .rel-mor w (notRes U , x₁) (_ , x₂) (refl , x₁₂) =
     trans (cong not x₁₂) (eval-negate x₂ (w .env))
 
   ------------------------------------------------------------------------------
@@ -436,17 +437,17 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
   ⟦return⟧ .right = 𝒩.⟦return⟧
   ⟦return⟧ .rel-mor w x₁ x₂ r-x₁x₂ = r-x₁x₂
 
-  ⟦extFunc⟧ : ⟦Num⟧ linear ==> LiftMR (⟦Num⟧ linear)
+  ⟦extFunc⟧ : ∀ {l₁ l₂} → (Flat (FuncRel l₁ l₂) ⟦×⟧ ⟦Num⟧ l₁) ==> LiftMR (⟦Num⟧ l₂)
   ⟦extFunc⟧ .left = 𝒮.⟦extFunc⟧
   ⟦extFunc⟧ .right = 𝒩.⟦extFunc⟧
-  ⟦extFunc⟧ .rel-mor w x₁ x₂ r-x₁x₂ =
+  ⟦extFunc⟧ .rel-mor w (linear-linear , x₁) (linear-linear , x₂) (_ , r-x₁x₂) =
     trans (cong extFunc r-x₁x₂) (sym (*-identityˡ _))
 
-  ⟦if⟧ : ∀ {X} → ((LiftMR X ⟦×⟧ LiftMR X) ⟦×⟧ ⟦Bool⟧ linear U) ==> LiftMR X
+  ⟦if⟧ : ∀ {X b} → ((LiftMR X ⟦×⟧ LiftMR X) ⟦×⟧ (Flat (IfRes b) ⟦×⟧ (⟦Bool⟧ b))) ==> LiftMR X
   ⟦if⟧ .left = 𝒮.⟦if⟧
   ⟦if⟧ .right = 𝒩.⟦if⟧
-  ⟦if⟧ .rel-mor w ((tr₁ , fa₁) , false) ((tr₂ , fa₂) , ϕ) ((tr₁-tr₂ , fa₁-fa₂) , eq) rewrite sym eq = fa₁-fa₂
-  ⟦if⟧ .rel-mor w ((tr₁ , fa₁) , true) ((tr₂ , fa₂) , ϕ) ((tr₁-tr₂ , fa₁-fa₂) , eq) rewrite sym eq = tr₁-tr₂
+  ⟦if⟧ .rel-mor w ((tr₁ , fa₁) , (ifRes _ , false)) ((tr₂ , fa₂) , (ifRes _ , ϕ)) ((tr₁-tr₂ , fa₁-fa₂) , (_ , eq)) rewrite sym eq = fa₁-fa₂
+  ⟦if⟧ .rel-mor w ((tr₁ , fa₁) , (ifRes _ , true)) ((tr₂ , fa₂) , (ifRes _ , ϕ)) ((tr₁-tr₂ , fa₁-fa₂) , (_ , eq)) rewrite sym eq = tr₁-tr₂
 
   extendR : ∀ {X Y Z} → ((X ⟦×⟧ Y) ==> LiftMR Z) → (X ⟦×⟧ LiftMR Y) ==> LiftMR Z
   extendR f .left = 𝒮.⟦extend⟧ (f .left)
@@ -459,7 +460,7 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
       λ w' ρ y₁ y₂ y₁y₂ →
         f .rel-mor w' (x₁ , y₁) (X .Right .N.rename (ρ .ren) x₂ , y₂) (X .ext ρ x₁ x₂ x₁x₂ , y₁y₂)
 
-  compile-lemma : ∀ l w x₁ x₂ → LetLiftR (⟦Bool⟧ l Ex) w x₁ x₂ → ExFormulaR w x₁ (N.compile x₂)
+  compile-lemma : ∀ l w x₁ x₂ → LetLiftR (⟦Bool⟧ (l , Ex)) w x₁ x₂ → ExFormulaR w x₁ (N.compile x₂)
   compile-lemma l w x₁ (N.return x) r = r
   compile-lemma l w x₁ (N.if ϕ tr fa) r with is-true-or-false (eval-Constraint ϕ (w .env))
   ... | inj₁ is-true =
@@ -485,10 +486,10 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
           q = extFunc (w .env x)
 
   ⟦∃⟧ : ∀ {p₁ p₂ l} →
-       (Flat (QuantifyRel p₁ p₂) ⟦×⟧ (⟦Num⟧ linear ⟦⇒⟧ LiftMR (⟦Bool⟧ l p₁))) ==> ⟦Bool⟧ l p₂
+       (Flat (QuantRes l p₁ p₂) ⟦×⟧ (⟦Num⟧ l ⟦⇒⟧ LiftMR (⟦Bool⟧ p₁))) ==> ⟦Bool⟧ p₂
   ⟦∃⟧ .left = 𝒮.⟦∃⟧
   ⟦∃⟧ {l = l} .right = 𝒩.⟦∃⟧ {l = l}
-  ⟦∃⟧ {l = l} .rel-mor w (U  , f₁) (_ , f₂) (refl , r) =
+  ⟦∃⟧ {l = l} .rel-mor w (quantRes U  , f₁) (quantRes U , f₂) (refl , r) =
     q-ex (λ q → compile-lemma l (extend-w w q)
                      (S.return (f₁ q))
                      (N.bind-let (f₂ (w .ctxt ,∙) succ (var 1ℚ zero))
@@ -500,7 +501,7 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
                        _
                        (r (extend-w w q) wk-w q (var 1ℚ zero) (sym (*-identityˡ q)))
                        λ w' ρ a b x → q-constraint (sym x)))
-  ⟦∃⟧ {l = l} .rel-mor w (Ex , f₁) (_ , f₂) (refl , r) =
+  ⟦∃⟧ {l = l} .rel-mor w (quantRes Ex , f₁) (quantRes Ex , f₂) (refl , r) =
     q-ex λ q → compile-lemma l (extend-w w q) (f₁ q) (f₂ (w .ctxt ,∙) succ (var 1ℚ zero))
                  (r (extend-w w q) wk-w q (var 1ℚ zero) (sym (*-identityˡ q)))
 
@@ -594,7 +595,7 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
     ⇔-trans (⊎-cong (toPrenexForm-ok ϕ η) (toPrenexForm-ok ψ η))
               (equi-disj (toPrenexForm ϕ) (toPrenexForm ψ) η)
 
-  ℳ : Model (suc 0ℓ) 0ℓ
+  ℳ : Model verifierRestriction (suc 0ℓ) 0ℓ
   ℳ .Model.⟦Type⟧ = WRel
   ℳ .Model._==>_ = _==>_
   ℳ .Model.Flat = Flat
@@ -631,17 +632,17 @@ module NormalisationCorrect (extFunc : ℚ → ℚ) where
   ℳ .Model.⟦idx⟧ = ⟦idx⟧
   ℳ .Model.⟦∃⟧ = ⟦∃⟧
 
-  open import MiniVehicle hiding (_⇒ᵣ_; under)
+  open import MiniVehicle verifierRestriction hiding (_⇒ᵣ_; under)
 
-  module ℐ = Interpret ℳ
+  module ℐ = Interpret verifierRestriction ℳ
 
-  standard : ε / ε ⊢ Bool (LinearityConst linear) (PolarityConst Ex) → Set
+  standard : ε / ε ⊢ Bool (BoolRes (linear , Ex)) → Set
   standard t = S.eval-Quant (ℐ.⟦ t ⟧tm (lift tt) .left tt) True
 
-  normalise : ε / ε ⊢ Bool (LinearityConst linear) (PolarityConst Ex) → PrenexFormula ε
+  normalise : ε / ε ⊢ Bool (BoolRes (linear , Ex)) → PrenexFormula ε
   normalise t = toPrenexForm (N.compile (ℐ.⟦ t ⟧tm (lift tt) .right .N.mor tt))
 
-  full-correctness : (t : ε / ε ⊢ Bool (LinearityConst linear) (PolarityConst Ex)) →
+  full-correctness : (t : ε / ε ⊢ Bool (BoolRes (linear , Ex))) →
                      standard t ⇔ eval-PrenexFormula (normalise t) (empty .env)
   full-correctness t =
     ⇔-trans

--- a/src/StandardSemantics.agda
+++ b/src/StandardSemantics.agda
@@ -30,7 +30,7 @@ eval-Quant (x or y) k = (eval-Quant x k) ⊎ (eval-Quant y k)
 module _ (extFunc : ℚ → ℚ) where
   open Model
 
-  ℳ : Model (suc 0ℓ) 0ℓ
+  ℳ : Model verifierRestriction (suc 0ℓ) 0ℓ
   ℳ .⟦Type⟧ = Set
   ℳ ._==>_ X Y = X → Y
   ℳ .Flat X = X
@@ -56,22 +56,22 @@ module _ (extFunc : ℚ → ℚ) where
   ℳ .⟦add⟧ (_ , x , y)  = x +ℚ y
   ℳ .⟦mul⟧ (_ , x , y)  = x *ℚ y
   ℳ .⟦const⟧ q _ = q
-  ℳ .⟦extFunc⟧ x  = extFunc (x )
-  ℳ .⟦Bool⟧ _ U = 𝔹
-  ℳ .⟦Bool⟧ _ Ex = Quant 𝔹
-  ℳ .⟦not⟧ (U , x) = not x
-  ℳ .⟦and⟧ (p , U-U , x , y) = x ∧ y
-  ℳ .⟦and⟧ (p , U-Ex , x , y) = (return x) and y
-  ℳ .⟦and⟧ (p , Ex-U , x , y) = x and (return y)
-  ℳ .⟦and⟧ (p , Ex-Ex , x , y) = x and y
-  ℳ .⟦or⟧ (_ , U-U , x , y) = x ∨ y
-  ℳ .⟦or⟧ (_ , U-Ex , x , y) = (return x) or y
-  ℳ .⟦or⟧ (_ , Ex-U , x , y) = x or (return y)
-  ℳ .⟦or⟧ (_ , Ex-Ex , x , y) = x or y
-  ℳ .⟦≤⟧ (_ , q₁ , q₂)  = q₁  ≤ᵇ q₂
-  ℳ .⟦if⟧ ((tr , fa) , false) = fa
-  ℳ .⟦if⟧ ((tr , fa) , true) = tr
+  ℳ .⟦extFunc⟧ (_ , v)  = extFunc v
+  ℳ .⟦Bool⟧ (_ , U) = 𝔹
+  ℳ .⟦Bool⟧ (_ , Ex) = Quant 𝔹
+  ℳ .⟦not⟧ (notRes U , x) = not x
+  ℳ .⟦and⟧ (maxBoolRes _ U-U , x , y) = x ∧ y
+  ℳ .⟦and⟧ (maxBoolRes _ U-Ex , x , y) = (return x) and y
+  ℳ .⟦and⟧ (maxBoolRes _ Ex-U , x , y) = x and (return y)
+  ℳ .⟦and⟧ (maxBoolRes _ Ex-Ex , x , y) = x and y
+  ℳ .⟦or⟧ (maxBoolRes _ U-U , x , y) = x ∨ y
+  ℳ .⟦or⟧ (maxBoolRes _ U-Ex , x , y) = (return x) or y
+  ℳ .⟦or⟧ (maxBoolRes _ Ex-U , x , y) = x or (return y)
+  ℳ .⟦or⟧ (maxBoolRes _ Ex-Ex , x , y) = x or y
+  ℳ .⟦≤⟧ (leqRes _ , q₁ , q₂) = q₁  ≤ᵇ q₂
+  ℳ .⟦if⟧ ((tr , fa) , (ifRes _ , true)) = tr
+  ℳ .⟦if⟧ ((tr , fa) , (ifRes _ , false)) = fa
   ℳ .⟦Index⟧ i = Fin i
   ℳ .⟦idx⟧ _ i _  = i
-  ℳ .⟦∃⟧ (U , f) = ex (λ q → return (f q))
-  ℳ .⟦∃⟧ (Ex , f) = ex f
+  ℳ .⟦∃⟧ (quantRes U , f) = ex (λ q → return (f q))
+  ℳ .⟦∃⟧ (quantRes Ex , f) = ex f


### PR DESCRIPTION
Adds a new file `MiniVehicle.Restriction` containing a record `SyntaxRestriction`, which the syntax is then parameterised by and then pushing this change through the proofs.